### PR TITLE
Upgrade to Salt 2014.1.0

### DIFF
--- a/devpi/init.sls
+++ b/devpi/init.sls
@@ -8,7 +8,7 @@
     - group: web
     - mode: 755
     - require:
-      - file.directory: /home/web/repo
+      - file: /home/web/repo
 
 /home/web/repo/devpi/data:
   file.directory:
@@ -16,7 +16,7 @@
     - group: web
     - mode: 755
     - require:
-      - file.directory: /home/web/repo/devpi
+      - file: /home/web/repo/devpi
 
 /home/web/repo/devpi/venv_devpi:
   virtualenv.manage:
@@ -24,6 +24,6 @@
     - requirements: salt://devpi/requirements.txt
     - require:
       - pkg: python-virtualenv
-      - file.directory: /home/web/repo/devpi
+      - file: /home/web/repo/devpi
 
 {% endif %}

--- a/ftp/init.sls
+++ b/ftp/init.sls
@@ -29,7 +29,7 @@
       - group: root
       - mode: 644
       - require:
-        - pkg.installed: vsftpd
+        - pkg: vsftpd
 
   /etc/vsftpd.userlist:
     file:
@@ -50,7 +50,7 @@
         - user
         - group
       - require:
-        - file.directory: /home/web/repo
+        - file: /home/web/repo
 {% endif %}
 
 {% for site, settings in sites.iteritems() %}
@@ -65,7 +65,7 @@
         - user
         - group
       - require:
-        - file.directory: /home/web/repo/ftp
+        - file: /home/web/repo/ftp
 
   ftp_group_{{ site }}:
     group.present:
@@ -97,7 +97,7 @@
       - user: {{ site }}
       - group: {{ site }}
       - require:
-        - file.directory: /home/{{ site }}/site
+        - file: /home/{{ site }}/site
       - mode: 755
 
   /home/{{ site }}/site/templates:
@@ -105,7 +105,7 @@
       - user: {{ site }}
       - group: {{ site }}
       - require:
-        - file.directory: /home/{{ site }}/site
+        - file: /home/{{ site }}/site
       - mode: 755
 
   /home/{{ site }}/site/templates/templatepages:
@@ -113,7 +113,7 @@
       - user: {{ site }}
       - group: {{ site }}
       - require:
-        - file.directory: /home/{{ site }}/site/templates
+        - file: /home/{{ site }}/site/templates
       - mode: 755
 
   {# symlink uploads to site folder #}
@@ -121,8 +121,8 @@
     file.symlink:
       - target: /home/{{ site }}/site
       - require:
-        - file.directory: /home/web/repo/ftp/{{ site }}
-        - file.directory: /home/{{ site }}/site
+        - file: /home/web/repo/ftp/{{ site }}
+        - file: /home/{{ site }}/site
 
 {% endif %}
 {% endfor %}

--- a/solr/file.sls
+++ b/solr/file.sls
@@ -10,7 +10,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/conf/Catalina/localhost/solr.xml:
   file.managed:
@@ -19,7 +19,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/shared/jcl-over-slf4j-1.6.6.jar:
   file.managed:
@@ -28,7 +28,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/shared/jul-to-slf4j-1.6.6.jar:
   file.managed:
@@ -37,7 +37,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/shared/log4j-1.2.16.jar:
   file.managed:
@@ -46,7 +46,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/shared/log4j.properties:
   file.managed:
@@ -55,7 +55,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/shared/slf4j-api-1.6.6.jar:
   file.managed:
@@ -64,7 +64,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/lib/tomcat7/shared/slf4j-log4j12-1.6.6.jar:
   file.managed:
@@ -73,7 +73,7 @@
     - group: root
     - mode: 644
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/data/solr/war/solr.war:
   file.managed:
@@ -82,7 +82,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/war
+      - file: /var/data/solr/war
 
 /var/data/solr/multicore/solr.xml:
   file.managed:
@@ -92,7 +92,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/multicore
+      - file: /var/data/solr/multicore
 
 /var/data/solr/multicore/zoo.cfg:
   file.managed:
@@ -101,7 +101,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/multicore
+      - file: /var/data/solr/multicore
 
 {% for site, settings in sites.iteritems() %}
 
@@ -112,7 +112,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/multicore/{{ site }}
+      - file: /var/data/solr/multicore/{{ site }}
 
 /var/data/solr/multicore/{{ site }}/conf/solrconfig.xml:
   file.managed:
@@ -124,7 +124,7 @@
     - context:
       site: {{ site }}
     - require:
-      - file.directory: /var/data/solr/multicore/{{ site }}
+      - file: /var/data/solr/multicore/{{ site }}
 
 /var/data/solr/multicore/{{ site }}/conf/stopwords.txt:
   file.managed:
@@ -133,7 +133,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/multicore/{{ site }}
+      - file: /var/data/solr/multicore/{{ site }}
 
 /var/data/solr/multicore/{{ site }}/conf/stopwords_en.txt:
   file.managed:
@@ -142,7 +142,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/multicore/{{ site }}
+      - file: /var/data/solr/multicore/{{ site }}
 
 /var/data/solr/multicore/{{ site }}/conf/synonyms.txt:
   file.managed:
@@ -151,7 +151,7 @@
     - group: tomcat7
     - mode: 644
     - require:
-      - file.directory: /var/data/solr/multicore/{{ site }}
+      - file: /var/data/solr/multicore/{{ site }}
 
 {% endfor %}
 {% endif %}

--- a/solr/folder.sls
+++ b/solr/folder.sls
@@ -9,7 +9,7 @@
     - group: root
     - mode: 755
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 /var/data/solr:
   file.directory:
@@ -25,7 +25,7 @@
     - group: tomcat7
     - mode: 755
     - require:
-      - file.directory: /var/data/solr
+      - file: /var/data/solr
 
 /var/data/solr/multicore:
   file.directory:
@@ -33,7 +33,7 @@
     - group: tomcat7
     - mode: 755
     - require:
-      - file.directory: /var/data/solr
+      - file: /var/data/solr
 
 {% for site, settings in sites.iteritems() %}
 
@@ -43,7 +43,7 @@
     - group: tomcat7
     - mode: 755
     - require:
-      - file.directory: /var/data/solr/multicore
+      - file: /var/data/solr/multicore
 
 /var/data/solr/multicore/{{ site }}/conf:
   file.directory:
@@ -51,7 +51,7 @@
     - group: tomcat7
     - mode: 755
     - require:
-      - file.directory: /var/data/solr/multicore/{{ site }}
+      - file: /var/data/solr/multicore/{{ site }}
 
 {% endfor %}
 {% endif %}

--- a/solr/service.sls
+++ b/solr/service.sls
@@ -7,6 +7,6 @@ tomcat-service:
     - name: tomcat7
     - enable: True
     - require:
-      - pkg.installed: tomcat7
+      - pkg: tomcat7
 
 {% endif %}

--- a/uwsgi/init.sls
+++ b/uwsgi/init.sls
@@ -12,7 +12,7 @@
     - group: web
     - mode: 755
     - require:
-      - file.directory: /home/web/repo
+      - file: /home/web/repo
 
 /home/web/repo/uwsgi/log:
   file.directory:
@@ -20,7 +20,7 @@
     - group: web
     - mode: 755
     - require:
-      - file.directory: /home/web/repo/uwsgi
+      - file: /home/web/repo/uwsgi
 
 /home/web/repo/uwsgi/vassals:
   file.directory:
@@ -28,7 +28,7 @@
     - group: web
     - mode: 755
     - require:
-      - file.directory: /home/web/repo/uwsgi
+      - file: /home/web/repo/uwsgi
 
 {% for site, settings in sites.iteritems() %}
 
@@ -44,7 +44,7 @@
       postgres_settings: {{ postgres_settings }}
       settings: {{ settings }}
     - require:
-      - file.directory: /home/web/repo/uwsgi/vassals
+      - file: /home/web/repo/uwsgi/vassals
 
 {% endfor %}
 
@@ -63,7 +63,7 @@
       - user
       - group
     - require:
-      - file.directory: /home/web/repo/uwsgi
+      - file: /home/web/repo/uwsgi
 
 /home/web/opt/runinenv.sh:                  # ID declaration
   file:                                     # state declaration
@@ -74,7 +74,7 @@
     - require:                              # requisite declaration
       - pkg: python-virtualenv              # requisite reference
     - require:
-      - file.directory: /home/web/opt
+      - file: /home/web/opt
       - user: web
 
 {% endif %}

--- a/web/file.sls
+++ b/web/file.sls
@@ -24,7 +24,7 @@
     - mode: 755
     - makedirs: True
     - require:
-      - file.directory: /home/web/opt
+      - file: /home/web/opt
       - user: web
 
 
@@ -42,7 +42,7 @@
     - context:
       site: {{ site }}
     - require:
-      - file.directory: /home/web/opt
+      - file: /home/web/opt
       - user: web
 
 /etc/cron.d/{{ site }}_update_index:

--- a/web/folder.sls
+++ b/web/folder.sls
@@ -26,7 +26,7 @@
       - group
       - mode
     - require:
-      - file.directory: /home/web/repo
+      - file: /home/web/repo
 
 /home/web/repo/project:
   file.directory:
@@ -39,7 +39,7 @@
       - group
       - mode
     - require:
-      - file.directory: /home/web/repo
+      - file: /home/web/repo
 
 {% for site, settings in sites.iteritems() %}
 
@@ -54,7 +54,7 @@
       - user
       - group
     - require:
-      - file.directory: /home/web/repo/files
+      - file: /home/web/repo/files
 
 {# 'files/site/private' folder is for private attachments #}
 /home/web/repo/files/{{ site }}/private:
@@ -67,7 +67,7 @@
       - user
       - group
     - require:
-      - file.directory: /home/web/repo/files
+      - file: /home/web/repo/files
 
 {# 'project' folder is for the code #}
 /home/web/repo/project/{{ site }}:
@@ -80,7 +80,7 @@
       - user
       - group
     - require:
-      - file.directory: /home/web/repo/project
+      - file: /home/web/repo/project
 
 {% endfor %}
 {% endif %}

--- a/web/package.sls
+++ b/web/package.sls
@@ -15,7 +15,7 @@ git:
 python-dev:
   pkg.installed:
     - require:
-      - pkg.installed: build-essential
+      - pkg: build-essential
 
 python-virtualenv:
   pkg.installed


### PR DESCRIPTION
When specifing requisite definition (- require), no '.' is allowed so
for example file.directory: becomes file:
